### PR TITLE
Import iperf3-3.9-13.el9.src.rpm

### DIFF
--- a/SOURCES/0000-cve-2023-38403.patch
+++ b/SOURCES/0000-cve-2023-38403.patch
@@ -1,0 +1,45 @@
+From 41f5129d402bcd14ec4d2cde875203ab51076352 Mon Sep 17 00:00:00 2001
+From: "Bruce A. Mah" <bmah@es.net>
+Date: Fri, 7 Jul 2023 11:03:43 -0700
+Subject: [PATCH] Fix memory allocation hazard (#1542).
+
+Reported by:	@someusername123 on GitHub
+---
+ src/iperf_api.c | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/src/iperf_api.c b/src/iperf_api.c
+index f2d416214..a95e02418 100644
+--- a/src/iperf_api.c
++++ b/src/iperf_api.c
+@@ -2670,6 +2670,7 @@ static cJSON *
+ JSON_read(int fd)
+ {
+     uint32_t hsize, nsize;
++    size_t strsize;
+     char *str;
+     cJSON *json = NULL;
+     int rc;
+@@ -2682,7 +2683,9 @@ JSON_read(int fd)
+     if (Nread(fd, (char*) &nsize, sizeof(nsize), Ptcp) >= 0) {
+ 	hsize = ntohl(nsize);
+ 	/* Allocate a buffer to hold the JSON */
+-	str = (char *) calloc(sizeof(char), hsize+1);	/* +1 for trailing null */
++	strsize = hsize + 1;              /* +1 for trailing NULL */
++	if (strsize) {
++	str = (char *) calloc(sizeof(char), strsize);
+ 	if (str != NULL) {
+ 	    rc = Nread(fd, str, hsize, Ptcp);
+ 	    if (rc >= 0) {
+@@ -2701,6 +2704,10 @@ JSON_read(int fd)
+ 	    }
+ 	}
+ 	free(str);
++	}
++	else {
++	    printf("WARNING:  Data length overflow\n");
++	}
+     }
+     return json;
+ }
+

--- a/SOURCES/0001-cve-2023-7250.patch
+++ b/SOURCES/0001-cve-2023-7250.patch
@@ -1,0 +1,129 @@
+From 5e3704dd850a5df2fb2b3eafd117963d017d07b4 Mon Sep 17 00:00:00 2001
+From: "Bruce A. Mah" <bmah@es.net>
+Date: Tue, 1 Aug 2023 14:02:54 -0700
+Subject: [PATCH] Implement fixes to make the control connection more robust.
+
+These include various timeouts in Nread() to guarantee that it will
+eventually exit, a 10-second timeout for each attempt to read data
+from the network and an approximately 30-second overall timeout per
+Nread() call.
+
+Also the iperf3 server now checks the length of the received session
+cookie, and errors out if this happens to be incorrect.
+
+Reported by Jorge Sancho Larraz - Canonical.
+---
+ src/iperf_server_api.c |  7 ++++-
+ src/net.c              | 62 ++++++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 68 insertions(+), 1 deletion(-)
+
+diff --git a/src/iperf_server_api.c b/src/iperf_server_api.c
+index 5fa1dd7..c528d5f 100644
+--- a/src/iperf_server_api.c
++++ b/src/iperf_server_api.c
+@@ -118,7 +118,12 @@ iperf_accept(struct iperf_test *test)
+     if (test->ctrl_sck == -1) {
+         /* Server free, accept new client */
+         test->ctrl_sck = s;
+-        if (Nread(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) < 0) {
++        if (Nread(test->ctrl_sck, test->cookie, COOKIE_SIZE, Ptcp) != COOKIE_SIZE) {
++            /*
++             * Note this error covers both the case of a system error
++             * or the inability to read the correct amount of data
++             * (i.e. timed out).
++             */
+             i_errno = IERECVCOOKIE;
+             return -1;
+         }
+diff --git a/src/net.c b/src/net.c
+index fd525ee..8804a39 100644
+--- a/src/net.c
++++ b/src/net.c
+@@ -60,10 +60,14 @@
+ #include <poll.h>
+ #endif /* HAVE_POLL_H */
+ 
++#include "iperf.h"
+ #include "iperf_util.h"
+ #include "net.h"
+ #include "timer.h"
+ 
++static int nread_read_timeout = 10;
++static int nread_overall_timeout = 30;
++
+ /*
+  * Declaration of gerror in iperf_error.c.  Most other files in iperf3 can get this
+  * by including "iperf.h", but net.c lives "below" this layer.  Clearly the
+@@ -313,6 +317,32 @@ Nread(int fd, char *buf, size_t count, int prot)
+ {
+     register ssize_t r;
+     register size_t nleft = count;
++    struct iperf_time ftimeout = { 0, 0 };
++
++    fd_set rfdset;
++    struct timeval timeout = { nread_read_timeout, 0 };
++
++    /*
++     * fd might not be ready for reading on entry. Check for this
++     * (with timeout) first.
++     *
++     * This check could go inside the while() loop below, except we're
++     * currently considering whether it might make sense to support a
++     * codepath that bypassese this check, for situations where we
++     * already know that fd has data on it (for example if we'd gotten
++     * to here as the result of a select() call.
++     */
++    {
++        FD_ZERO(&rfdset);
++        FD_SET(fd, &rfdset);
++        r = select(fd + 1, &rfdset, NULL, NULL, &timeout);
++        if (r < 0) {
++            return NET_HARDERROR;
++        }
++        if (r == 0) {
++            return 0;
++        }
++    }
+ 
+     while (nleft > 0) {
+         r = read(fd, buf, nleft);
+@@ -326,6 +356,39 @@ Nread(int fd, char *buf, size_t count, int prot)
+ 
+         nleft -= r;
+         buf += r;
++
++        /*
++         * We need some more bytes but don't want to wait around
++         * forever for them. In the case of partial results, we need
++         * to be able to read some bytes every nread_timeout seconds.
++         */
++        if (nleft > 0) {
++            struct iperf_time now;
++
++            /*
++             * Also, we have an approximate upper limit for the total time
++             * that a Nread call is supposed to take. We trade off accuracy
++             * of this timeout for a hopefully lower performance impact.
++             */
++            iperf_time_now(&now);
++            if (ftimeout.secs == 0) {
++                ftimeout = now;
++                iperf_time_add_usecs(&ftimeout, nread_overall_timeout * 1000000L);
++            }
++            if (iperf_time_compare(&ftimeout, &now) < 0) {
++                break;
++            }
++
++            FD_ZERO(&rfdset);
++            FD_SET(fd, &rfdset);
++            r = select(fd + 1, &rfdset, NULL, NULL, &timeout);
++            if (r < 0) {
++                return NET_HARDERROR;
++            }
++            if (r == 0) {
++                break;
++            }
++        }
+     }
+     return count - nleft;
+ }

--- a/SOURCES/0002-cve-2024-26306.patch
+++ b/SOURCES/0002-cve-2024-26306.patch
@@ -1,0 +1,315 @@
+From 299b356df6939f71619bf45bf7a7d2222e17d840 Mon Sep 17 00:00:00 2001
+From: Sarah Larsen <swlarsen@Sarahs-MBP.lan>
+Date: Wed, 20 Mar 2024 17:02:31 -0700
+Subject: [PATCH] Using OAEP padding instead of PKCS1 padding for OpenSSL. Fix
+ for CVE-2024-26306.
+
+Special thanks to Hubert Kario at Red Hat for finding the vulnerability.
+
+diff --git a/src/iperf.h b/src/iperf.h
+index c1d839be1..527e549ed 100644
+--- a/src/iperf.h
++++ b/src/iperf.h
+@@ -319,6 +319,7 @@ struct iperf_test
+ #if defined(HAVE_SSL)
+     char      *server_authorized_users;
+     EVP_PKEY  *server_rsa_private_key;
++    int       use_pkcs1_padding;
+ #endif // HAVE_SSL
+ 
+     /* boolean variables for Options */
+diff --git a/src/iperf_api.c b/src/iperf_api.c
+index d40561c10..7fb741e77 100644
+--- a/src/iperf_api.c
++++ b/src/iperf_api.c
+@@ -1137,6 +1137,7 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
+     {"rsa-public-key-path", required_argument, NULL, OPT_CLIENT_RSA_PUBLIC_KEY},
+     {"rsa-private-key-path", required_argument, NULL, OPT_SERVER_RSA_PRIVATE_KEY},
+     {"authorized-users-path", required_argument, NULL, OPT_SERVER_AUTHORIZED_USERS},
++    {"use-pkcs1-padding", no_argument, NULL, OPT_USE_PKCS1_PADDING},
+ #endif /* HAVE_SSL */
+ 	{"fq-rate", required_argument, NULL, OPT_FQ_RATE},
+ 	{"pacing-timer", required_argument, NULL, OPT_PACING_TIMER},
+@@ -1630,6 +1631,9 @@ iperf_parse_arguments(struct iperf_test *test, int argc, char **argv)
+         case OPT_SERVER_AUTHORIZED_USERS:
+             test->server_authorized_users = strdup(optarg);
+             break;
++	       case OPT_USE_PKCS1_PADDING:
++	           test->use_pkcs1_padding = 1;
++	           break;
+ #endif /* HAVE_SSL */
+ 	    case OPT_PACING_TIMER:
+ 		test->settings->pacing_timer = unit_atoi(optarg);
+@@ -2070,7 +2074,7 @@ int test_is_authorized(struct iperf_test *test){
+     if (test->settings->authtoken){
+         char *username = NULL, *password = NULL;
+         time_t ts;
+-        int rc = decode_auth_setting(test->debug, test->settings->authtoken, test->server_rsa_private_key, &username, &password, &ts);
++        int rc = decode_auth_setting(test->debug, test->settings->authtoken, test->server_rsa_private_key, &username, &password, &ts, test->use_pkcs1_padding);
+ 	if (rc) {
+ 	    return -1;
+ 	}
+@@ -2255,7 +2259,7 @@ send_parameters(struct iperf_test *test)
+ #if defined(HAVE_SSL)
+ 	/* Send authentication parameters */
+ 	if (test->settings->client_username && test->settings->client_password && test->settings->client_rsa_pubkey){
+-	    int rc = encode_auth_setting(test->settings->client_username, test->settings->client_password, test->settings->client_rsa_pubkey, &test->settings->authtoken);
++	    int rc = encode_auth_setting(test->settings->client_username, test->settings->client_password, test->settings->client_rsa_pubkey, &test->settings->authtoken, test->use_pkcs1_padding);
+ 
+ 	    if (rc) {
+ 		cJSON_Delete(j);
+diff --git a/src/iperf_api.h b/src/iperf_api.h
+index d2bbdfe96..131314243 100644
+--- a/src/iperf_api.h
++++ b/src/iperf_api.h
+@@ -100,6 +100,7 @@ typedef atomic_uint_fast64_t atomic_iperf_size_t;
+ #define OPT_BIDIRECTIONAL 20
+ #define OPT_SERVER_BITRATE_LIMIT 21
+ #define OPT_TIMESTAMPS 22
++#define OPT_USE_PKCS1_PADDING 30
+ 
+ /* states */
+ #define TEST_START 1
+diff --git a/src/t_auth.c b/src/t_auth.c
+index 77c225531..3b0fd2f32 100644
+--- a/src/t_auth.c
++++ b/src/t_auth.c
+@@ -101,8 +101,9 @@ test_authtoken(const char *authUser, const char *authPassword, EVP_PKEY *pubkey,
+     char *decodePassword;
+     time_t decodeTime;
+ 
+-    assert(encode_auth_setting(authUser, authPassword, pubkey, &authToken) == 0);
+-    assert(decode_auth_setting(0, authToken, privkey, &decodeUser, &decodePassword, &decodeTime) == 0);
++    int use_pkcs1_padding = 1;
++    assert(encode_auth_setting(authUser, authPassword, pubkey, &authToken, use_pkcs1_padding) == 0);
++    assert(decode_auth_setting(0, authToken, privkey, &decodeUser, &decodePassword, &decodeTime, use_pkcs1_padding) == 0);
+ 
+     assert(strcmp(decodeUser, authUser) == 0);
+     assert(strcmp(decodePassword, authPassword) == 0);
+diff --git a/src/iperf_auth.c b/src/iperf_auth.c
+index eb4610f..2025a71 100644
+--- a/src/iperf_auth.c
++++ b/src/iperf_auth.c
+@@ -44,6 +44,10 @@
+ #include <openssl/sha.h>
+ #include <openssl/buffer.h>
+ #include <openssl/err.h>
++#if OPENSSL_VERSION_MAJOR >= 3
++#include <openssl/evp.h>
++#include <openssl/core_names.h>
++#endif
+ 
+ const char *auth_text_format = "user: %s\npwd:  %s\nts:   %ld";
+ 
+@@ -224,61 +224,123 @@ int test_load_private_key_from_file(const char *file){
+     return 0;
+ }
+ 
+-int encrypt_rsa_message(const char *plaintext, EVP_PKEY *public_key, unsigned char **encryptedtext) {
++int encrypt_rsa_message(const char *plaintext, EVP_PKEY *public_key, unsigned char **encryptedtext, int use_pkcs1_padding) {
++#if OPENSSL_VERSION_MAJOR >= 3
++    EVP_PKEY_CTX *ctx;
++#else
+     RSA *rsa = NULL;
+-    unsigned char *rsa_buffer = NULL, pad = RSA_PKCS1_PADDING;
+-    int keysize, encryptedtext_len, rsa_buffer_len;
+-
++#endif
++    unsigned char *rsa_buffer = NULL;
++    size_t encryptedtext_len = 0;
++    int rsa_buffer_len, keysize;
++
++#if OPENSSL_VERSION_MAJOR >= 3
++    int rc;
++    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, public_key, "");
++    /* See evp_pkey_rsa(7) and provider-keymgmt(7) */
++    rc = EVP_PKEY_get_int_param(public_key, OSSL_PKEY_PARAM_MAX_SIZE, &keysize); /* XXX not really keysize */
++    if (!rc) {
++        goto errreturn;
++    }
++#else
+     rsa = EVP_PKEY_get1_RSA(public_key);
+     keysize = RSA_size(rsa);
+-
++#endif
+     rsa_buffer  = OPENSSL_malloc(keysize * 2);
+     *encryptedtext = (unsigned char*)OPENSSL_malloc(keysize);
+ 
+     BIO *bioBuff   = BIO_new_mem_buf((void*)plaintext, (int)strlen(plaintext));
+     rsa_buffer_len = BIO_read(bioBuff, rsa_buffer, keysize * 2);
+-    encryptedtext_len = RSA_public_encrypt(rsa_buffer_len, rsa_buffer, *encryptedtext, rsa, pad);
+ 
++    int padding = RSA_PKCS1_OAEP_PADDING;
++    if (use_pkcs1_padding){
++        padding = RSA_PKCS1_PADDING;
++    }
++#if OPENSSL_VERSION_MAJOR >= 3
++    EVP_PKEY_encrypt_init(ctx);
++    EVP_PKEY_CTX_set_rsa_padding(ctx, padding);
++
++    EVP_PKEY_encrypt(ctx, *encryptedtext, &encryptedtext_len, rsa_buffer, rsa_buffer_len);
++    EVP_PKEY_CTX_free(ctx);
++#else
++    encryptedtext_len = RSA_public_encrypt(rsa_buffer_len, rsa_buffer, *encryptedtext, rsa, padding);
+     RSA_free(rsa);
++#endif
+     OPENSSL_free(rsa_buffer);
+     BIO_free(bioBuff);
+ 
+     if (encryptedtext_len < 0) {
+-      /* We probably shoudln't be printing stuff like this */
+-      fprintf(stderr, "%s\n", ERR_error_string(ERR_get_error(), NULL));
++        goto errreturn;
+     }
+ 
+     return encryptedtext_len;  
++
++  errreturn:
++    fprintf(stderr, "%s\n", ERR_error_string(ERR_get_error(), NULL));
++    return 0;
+ }
+ 
+-int decrypt_rsa_message(const unsigned char *encryptedtext, const int encryptedtext_len, EVP_PKEY *private_key, unsigned char **plaintext) {
++int decrypt_rsa_message(const unsigned char *encryptedtext, const int encryptedtext_len, EVP_PKEY *private_key, unsigned char **plaintext, int use_pkcs1_padding) {
++#if OPENSSL_VERSION_MAJOR >= 3
++    EVP_PKEY_CTX *ctx;
++#else
+     RSA *rsa = NULL;
+-    unsigned char *rsa_buffer = NULL, pad = RSA_PKCS1_PADDING;
+-    int plaintext_len, rsa_buffer_len, keysize;
++#endif
++    unsigned char *rsa_buffer = NULL;
++    size_t plaintext_len = 0;
++    int rsa_buffer_len, keysize;
+     
++#if OPENSSL_VERSION_MAJOR >= 3
++    int rc;
++    ctx = EVP_PKEY_CTX_new_from_pkey(NULL, private_key, "");
++    /* See evp_pkey_rsa(7) and provider-keymgmt(7) */
++    rc = EVP_PKEY_get_int_param(private_key, OSSL_PKEY_PARAM_MAX_SIZE, &keysize); /* XXX not really keysize */
++    if (!rc) {
++        goto errreturn;
++    }
++#else
+     rsa = EVP_PKEY_get1_RSA(private_key);
+-
+     keysize = RSA_size(rsa);
++#endif
+     rsa_buffer  = OPENSSL_malloc(keysize * 2);
+     *plaintext = (unsigned char*)OPENSSL_malloc(keysize);
+ 
+     BIO *bioBuff   = BIO_new_mem_buf((void*)encryptedtext, encryptedtext_len);
+     rsa_buffer_len = BIO_read(bioBuff, rsa_buffer, keysize * 2);
+-    plaintext_len = RSA_private_decrypt(rsa_buffer_len, rsa_buffer, *plaintext, rsa, pad);
+ 
++    int padding = RSA_PKCS1_OAEP_PADDING;
++    if (use_pkcs1_padding){
++        padding = RSA_PKCS1_PADDING;
++    }
++#if OPENSSL_VERSION_MAJOR >= 3
++    plaintext_len = keysize;
++    EVP_PKEY_decrypt_init(ctx);
++    int ret = EVP_PKEY_CTX_set_rsa_padding(ctx, padding);
++    if (ret < 0){
++        goto errreturn;
++    }
++    EVP_PKEY_decrypt(ctx, *plaintext, &plaintext_len, rsa_buffer, rsa_buffer_len);
++    EVP_PKEY_CTX_free(ctx);
++#else
++    plaintext_len = RSA_private_decrypt(rsa_buffer_len, rsa_buffer, *plaintext, rsa, padding);
+     RSA_free(rsa);
++#endif
++
+     OPENSSL_free(rsa_buffer);
+     BIO_free(bioBuff);
+ 
+     if (plaintext_len < 0) {
+-      /* We probably shoudln't be printing stuff like this */
+-      fprintf(stderr, "%s\n", ERR_error_string(ERR_get_error(), NULL));
++        plaintext_len = 0;
+     }
+ 
+     return plaintext_len;
++
++  errreturn:
++    fprintf(stderr, "%s\n", ERR_error_string(ERR_get_error(), NULL));
++    return 0;
+ }
+ 
+-int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken){
++int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken, int use_pkcs1_padding){
+     time_t t = time(NULL);
+     time_t utc_seconds = mktime(localtime(&t));
+ 
+@@ -295,7 +353,7 @@ int encode_auth_setting(const char *username, const char *password, EVP_PKEY *pu
+ 
+     unsigned char *encrypted = NULL;
+     int encrypted_len;
+-    encrypted_len = encrypt_rsa_message(text, public_key, &encrypted);
++    encrypted_len = encrypt_rsa_message(text, public_key, &encrypted, use_pkcs1_padding);
+     free(text);
+     if (encrypted_len < 0) {
+       return -1;
+@@ -306,14 +364,14 @@ int encode_auth_setting(const char *username, const char *password, EVP_PKEY *pu
+     return (0); //success
+ }
+ 
+-int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts){
++int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts, int use_pkcs1_padding){
+     unsigned char *encrypted_b64 = NULL;
+     size_t encrypted_len_b64;
+     Base64Decode(authtoken, &encrypted_b64, &encrypted_len_b64);        
+ 
+     unsigned char *plaintext = NULL;
+     int plaintext_len;
+-    plaintext_len = decrypt_rsa_message(encrypted_b64, encrypted_len_b64, private_key, &plaintext);
++    plaintext_len = decrypt_rsa_message(encrypted_b64, encrypted_len_b64, private_key, &plaintext, use_pkcs1_padding);
+     free(encrypted_b64);
+     if (plaintext_len < 0) {
+         return -1;
+diff --git a/src/iperf_auth.h b/src/iperf_auth.h
+index ffadbf3e5..eedd45abd 100644
+--- a/src/iperf_auth.h
++++ b/src/iperf_auth.h
+@@ -35,7 +35,7 @@ EVP_PKEY *load_pubkey_from_file(const char *file);
+ EVP_PKEY *load_pubkey_from_base64(const char *buffer);
+ EVP_PKEY *load_privkey_from_file(const char *file);
+ EVP_PKEY *load_privkey_from_base64(const char *buffer);
+-int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken);
+-int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts);
++int encode_auth_setting(const char *username, const char *password, EVP_PKEY *public_key, char **authtoken, int use_pkcs1_padding);
++int decode_auth_setting(int enable_debug, const char *authtoken, EVP_PKEY *private_key, char **username, char **password, time_t *ts, int use_pkcs1_padding);
+ int check_authentication(const char *username, const char *password, const time_t ts, const char *filename);
+ ssize_t iperf_getpass (char **lineptr, size_t *n, FILE *stream);
+diff --git a/src/iperf_locale.c b/src/iperf_locale.c
+index d5a5354..3b6860d 100644
+--- a/src/iperf_locale.c
++++ b/src/iperf_locale.c
+@@ -128,6 +128,7 @@ const char usage_longstr[] = "Usage: iperf3 [-s|-c host] [options]\n"
+ 			   "                            authentication credentials\n"
+                            "  --authorized-users-path   path to the configuration file containing user\n"
+                            "                            credentials\n"
++                           "  --use-pkcs1-padding       use pkcs1 padding at your own risk\n"
+ #endif //HAVE_SSL
+                            "Client specific:\n"
+                            "  -c, --client    <host>    run in client mode, connecting to <host>\n"
+diff --git a/src/iperf3.1 b/src/iperf3.1
+index 97d66ed..6fe71c9 100644
+--- a/src/iperf3.1
++++ b/src/iperf3.1
+@@ -161,6 +161,15 @@ Optionally, a format specification can be passed to customize the
+ timestamps, see
+ .BR strftime ( 3 ).
+ .TP
++.BR --use-pkcs1-padding
++This option is only meaningful when using iperf3's authentication
++features. Versions of iperf3 prior to 3.17 used PCKS1 padding in the
++RSA-encrypted credentials, which was vulnerable to a side-channel
++attack that could reveal a server's private key.  Beginning with
++iperf-3.17, OAEP padding is used, however this is a breaking change
++that is not compatible with older iperf3 versions.  Use this option to
++preserve the less secure, but more compatible, behavior.
++.TP
+ .BR -d ", " --debug " "
+ emit debugging output.
+ Primarily (perhaps exclusively) of use to developers.

--- a/SOURCES/3.9.tar.gz
+++ b/SOURCES/3.9.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6d8076b800f2b51f92dc941b0a9b77fbf2a867f623b5cb3cbf4754dabc40899
+size 627100

--- a/SPECS/iperf3.spec
+++ b/SPECS/iperf3.spec
@@ -1,0 +1,231 @@
+Name:           iperf3
+Version:        3.9
+Release:        13%{?dist}
+Summary:        Measurement tool for TCP/UDP bandwidth performance
+
+License:        BSD
+URL:            https://github.com/esnet/iperf
+Source0:        https://github.com/esnet/iperf/archive/%{version}.tar.gz
+Patch0000:	0000-cve-2023-38403.patch
+Patch0001:	0001-cve-2023-7250.patch
+Patch0002:	0002-cve-2024-26306.patch
+
+BuildRequires:  libuuid-devel
+BuildRequires:  gcc
+BuildRequires:  lksctp-tools-devel
+BuildRequires:  openssl-devel
+BuildRequires:  make
+
+%description
+Iperf is a tool to measure maximum TCP bandwidth, allowing the tuning of
+various parameters and UDP characteristics. Iperf reports bandwidth, delay
+jitter, data-gram loss.
+
+%package        devel
+Summary:        Development files for %{name}
+Requires:       %{name}%{?_isa} = %{version}-%{release}
+
+%description    devel
+The %{name}-devel package contains libraries and header files for
+developing applications that use %{name}.
+
+%prep
+%autosetup -n iperf-%{version} -p1
+
+%build
+%configure --disable-static
+sed -i 's|^hardcode_libdir_flag_spec=.*|hardcode_libdir_flag_spec=""|g' libtool
+sed -i 's|^runpath_var=LD_RUN_PATH|runpath_var=DIE_RPATH_DIE|g' libtool
+make %{?_smp_mflags}
+
+%install
+rm -rf $RPM_BUILD_ROOT
+%makeinstall -C src INSTALL_DIR="%{buildroot}%{_bindir}"
+mkdir -p %{buildroot}%{_mandir}/man1
+rm -f %{buildroot}%{_libdir}/libiperf.la
+
+%files
+%doc README.md LICENSE RELNOTES.md
+%{_mandir}/man1/iperf3.1.gz
+%{_mandir}/man3/libiperf.3.gz
+%{_bindir}/iperf3
+%{_libdir}/*.so.*
+
+%files          devel
+%{_includedir}/iperf_api.h
+%{_libdir}/*.so
+
+%changelog
+* Tue Jun 11 2024 Michal Ruprich <mruprich@redhat.com> - 3.9-13
+- Resolves: RHEL-29579 - vulnerable to marvin attack if the authentication option is used
+
+* Tue Jun 04 2024 Michal Ruprich <mruprich@redhat.com> - 3.9-12
+- Resolves: RHEL-39975 - possible denial of service
+
+* Wed Aug 09 2023 Michal Ruprich <mruprich@redhat.com> - 3.9-11
+- Related: #2223676 - bumping version for correct update path
+
+* Fri Jul 28 2023 Jonathan Wright <jonathan@almalinux.org> - 3.9-10
+- Fixes CVE-2023-38403
+  Resolves: rhbz#2223676
+
+* Mon Aug 09 2021 Mohan Boddu <mboddu@redhat.com> - 3.9-9
+- Rebuilt for IMA sigs, glibc 2.34, aarch64 flags
+  Related: rhbz#1991688
+
+* Wed Jun 16 2021 Mohan Boddu <mboddu@redhat.com> - 3.9-8
+- Rebuilt for RHEL 9 BETA for openssl 3.0
+  Related: rhbz#1971065
+
+* Fri Apr 16 2021 Mohan Boddu <mboddu@redhat.com> - 3.9-7
+- Rebuilt for RHEL 9 BETA on Apr 15th 2021. Related: rhbz#1947937
+
+* Tue Jan 26 2021 Fedora Release Engineering <releng@fedoraproject.org> - 3.9-6
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_34_Mass_Rebuild
+
+* Sat Oct 31 2020 Kevin Fenzi <kevin@scrye.com> - 3.9-5
+- Update to 3.9. Fixes bug #1846161
+
+* Tue Jul 28 2020 Fedora Release Engineering <releng@fedoraproject.org> - 3.7-5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_33_Mass_Rebuild
+
+* Wed Feb 19 2020 Michal Ruprich <mruprich@redhat.com> - 3.7-4
+- Add openssl-devel to BuildRequires to enable authentization of client
+
+* Wed Jan 29 2020 Fedora Release Engineering <releng@fedoraproject.org> - 3.7-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_32_Mass_Rebuild
+
+* Thu Jul 25 2019 Fedora Release Engineering <releng@fedoraproject.org> - 3.7-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_31_Mass_Rebuild
+
+* Sat Jun 22 2019 Kevin Fenzi <kevin@scrye.com> - 3.7-1
+- Update to 3.7. Fixes bug #1723020
+
+* Tue Feb 26 2019 Tomas Korbar <tkorbar@redhat.com> - 3.6-5
+- Add lksctp-tools-devel to BuildRequires
+- Fix bug #1647385
+
+* Fri Feb 01 2019 Fedora Release Engineering <releng@fedoraproject.org> - 3.6-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_30_Mass_Rebuild
+
+* Fri Jul 20 2018 Kevin Fenzi <kevin@scrye.com> - 3.6-3
+- Fix FTBFS bug #1604377 by adding BuildRequires: gcc
+
+* Fri Jul 13 2018 Fedora Release Engineering <releng@fedoraproject.org> - 3.6-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_29_Mass_Rebuild
+
+* Thu Jun 28 2018 Kevin Fenzi <kevin@scrye.com> - 3.6-1
+- Update to 3.6. Fixes bug #1594995
+
+* Sat Mar 03 2018 Kevin Fenzi <kevin@scrye.com> - 3.5-1
+- Update to 3.5. Fixes bug #1551166
+
+* Fri Feb 16 2018 Kevin Fenzi <kevin@scrye.com> - 3.4-1
+- Upgrade to 3.4. Fixes bug #1545468
+
+* Wed Feb 07 2018 Fedora Release Engineering <releng@fedoraproject.org> - 3.3-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_28_Mass_Rebuild
+
+* Sat Nov 04 2017 Kevin Fenzi <kevin@scrye.com> - 3.3-1
+- Update to 3.3. Fixes bug #1508669
+
+* Wed Aug 02 2017 Fedora Release Engineering <releng@fedoraproject.org> - 3.2-3
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Binutils_Mass_Rebuild
+
+* Wed Jul 26 2017 Fedora Release Engineering <releng@fedoraproject.org> - 3.2-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_27_Mass_Rebuild
+
+* Wed Jun 28 2017 Kevin Fenzi <kevin@scrye.com> - 3.2-1
+- Update to 3.2. Fixes bug #1465195
+
+* Wed Mar 08 2017 Kevin Fenzi <kevin@scrye.com> - 3.1.7-1
+- Update to 3.1.7. Fixes bug #1429901
+
+* Fri Feb 10 2017 Fedora Release Engineering <releng@fedoraproject.org> - 3.1.6-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_26_Mass_Rebuild
+
+* Fri Feb 03 2017 Kevin Fenzi <kevin@scrye.com> - 3.1.6-1
+- Update to 3.1.6. Fixes bug #1418879
+
+* Fri Jan 13 2017 Kevin Fenzi <kevin@scrye.com> - 3.1.5-1
+- Update to 3.1.5. Fixes bug #1412848
+
+* Sat Nov 05 2016 Kevin Fenzi <kevin@scrye.com> - 3.1.4-1
+- Update to 3.1.4. Fixes bug #1390396
+
+* Wed Jun 08 2016 Kevin Fenzi <kevin@scrye.com> - 3.1.3-1
+- Update to 3.1.3
+
+* Thu Feb 04 2016 Fedora Release Engineering <releng@fedoraproject.org> - 3.1b3-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_24_Mass_Rebuild
+
+* Thu Oct 08 2015 Susant Sahani <ssahani@gmail.com> 3.1b3
+- Update to 3.1b3
+
+* Wed Jun 17 2015 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0.11-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_23_Mass_Rebuild
+
+* Mon May 04 2015 Susant Sahani <ssahani@gmail.com> 3.0.11-1
+- Update to 3.0.11
+
+* Sat Dec 20 2014 Susant Sahani <ssahani@redhat.com> 3.0.10-1
+- Update to 3.0.10
+
+* Sat Aug 16 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0.6-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_22_Mass_Rebuild
+
+* Wed Jul 30 2014 Susant Sahani <ssahani@redhat.com> 3.0.6-1
+- Update to 3.0.6
+
+* Thu Jun 19 2014 Susant Sahani <ssahani@redhat.com> 3.0.5-1
+- Update to 3.0.5
+
+* Tue Jun 10 2014 Susant Sahani <ssahani@redhat.com> - 3.0.3-5
+- fix compilation BZ #1106803
+
+* Sat Jun 07 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0.3-4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
+
+* Wed Apr 2 2014 François Cami <fcami@fedoraproject.org> - 3.0.3-3
+- Drop static library support (#1081486).
+- iperf3-devel subpackage must require iperf3.
+- iperf3-devel should only contain the unversioned shared library.
+- Call ldconfig since we are installing a shared library now.
+- Removed INSTALL file.
+
+* Wed Apr 2 2014 Susant Sahani <ssahani@redhat.com> 3.0.3-2
+- Moved static library to devel section only .
+
+* Sun Mar 30 2014 Susant Sahani <ssahani@redhat.com> 3.0.3-1
+- Update to 3.0.3 and added devel rpm support
+
+* Tue Mar 11 2014 Susant Sahani <ssahani@redhat.com> 3.0.2-1
+- Update to 3.0.2
+
+* Tue Jan 14 2014 Susant Sahani <ssahani@redhat.com> 3.0.1-1
+- Update to 3.0.1
+
+* Fri Oct 25 2013 Steven Roberts <strobert@strobe.net> 3.0-1
+- Update to 3.0
+
+* Sat Aug 03 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0-0.5.b5
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_20_Mass_Rebuild
+
+* Sat May 04 2013 Kevin Fenzi <kevin@scrye.com> 3.0-0.4.b5
+- Update to 3.0b5
+
+* Thu Feb 14 2013 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0-0.3.b4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_19_Mass_Rebuild
+
+* Thu Jul 19 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0-0.2.b4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_18_Mass_Rebuild
+
+* Fri Jan 13 2012 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 3.0-0.1.b4
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_17_Mass_Rebuild
+
+* Wed Apr 06 2011 G.Balaji <balajig81@gmail.com> 3.0b4-2
+- Changed the Spec name, removed static libs generation and devel
+- package.
+
+* Sat Mar 26 2011 G.Balaji <balajig81@gmail.com> 3.0b4-1
+- Initial Version


### PR DESCRIPTION
Contains backported patches for CVEs 2023-38403, 2023-7250, and 2024-26306.

Koji scratch build: http://koji.xcp-ng.org/taskinfo?taskID=67149